### PR TITLE
Fix access checks with role middleware

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -11,7 +11,13 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->statefulApi();
+
+        $middleware->alias([
+            'auth'  => \App\Http\Middleware\Authenticate::class,
+            'role'  => \App\Http\Middleware\RoleMiddleware::class,
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -6,44 +6,39 @@ use App\Http\Controllers\Api\UserController;
 use App\Http\Controllers\Api\PetController;
 use App\Http\Controllers\Api\AppointmentController;
 use App\Http\Controllers\Api\ServiceController;
-use App\Http\Controllers\Api\VeterinarianController;
-use App\Http\Controllers\Api\NewsController;
 use App\Http\Controllers\Api\ServiceItemController;
 use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\VeterinarianController;
+use App\Http\Controllers\Api\NewsController;
 
-
-
-
-
-
-Route::get('/orders', [OrderController::class, 'index']);
-Route::post('/orders', [OrderController::class, 'store']);
-Route::delete('/orders/{order}', [OrderController::class, 'destroy']);
-
-
-
-
-
-Route::get('/veterinarians', [UserController::class, 'veterinarians']);
-Route::put('/users/{id}/role', [UserController::class, 'updateRole']);
-Route::post('/appointments/{appointment}/complete', [AppointmentController::class, 'complete']);
-Route::apiResource('services.items', ServiceItemController::class)->shallow();
-Route::apiResource('items', ServiceItemController::class)->only(['update', 'destroy']);
-Route::put('/users/{user}/role', [UserController::class, 'updateRole']);
-Route::get('/news', [NewsController::class, 'index']);
-Route::post('/news', [NewsController::class, 'store']);
-Route::get('/veterinarians/{veterinarian}/appointments/{date}', [AppointmentController::class, 'busySlots']);
-Route::get('/veterinarians/by-user/{user}', [VeterinarianController::class, 'byUser']);
-Route::get('/users/{user}/pets', [UserController::class, 'pets']);
-Route::get('/users', [UserController::class, 'index']);
-Route::get('/veterinarians', [VeterinarianController::class, 'index']);
-Route::apiResource('users', UserController::class);
-Route::apiResource('animals', PetController::class)->parameters([
-    'animals' => 'pet'
-]);
-Route::apiResource('appointments', AppointmentController::class);
-Route::apiResource('services', ServiceController::class);
-Route::apiResource('veterinarians',VeterinarianController::class);
+// Public authentication endpoints
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login',    [AuthController::class, 'login']);
-Route::post('/logout',   [AuthController::class, 'logout'])->name('api.logout');
+
+// Protected API routes via Sanctum
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout'])->name('api.logout');
+
+    Route::apiResource('orders', OrderController::class)->only(['index', 'store', 'destroy']);
+
+    Route::get('/news',  [NewsController::class, 'index']);
+    Route::post('/news', [NewsController::class, 'store']);
+
+    Route::get('/veterinarians/{veterinarian}/appointments/{date}', [AppointmentController::class, 'busySlots']);
+    Route::get('/veterinarians/by-user/{user}', [VeterinarianController::class, 'byUser']);
+    Route::apiResource('veterinarians', VeterinarianController::class)->only(['index', 'store', 'update', 'destroy']);
+
+    Route::get('/users/{user}/pets', [UserController::class, 'pets']);
+    Route::put('/users/{user}/role', [UserController::class, 'updateRole']);
+    Route::apiResource('users', UserController::class);
+
+    Route::apiResource('animals', PetController::class)->parameters(['animals' => 'pet']);
+
+    Route::post('/appointments/{appointment}/complete', [AppointmentController::class, 'complete']);
+    Route::apiResource('appointments', AppointmentController::class);
+
+    Route::apiResource('services', ServiceController::class);
+    Route::apiResource('services.items', ServiceItemController::class)->shallow();
+    Route::apiResource('items', ServiceItemController::class)->only(['update', 'destroy']);
+});
+

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -4,52 +4,56 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\PageController;
 
-
-
-
-
-
-
-
-Route::view('/orders', 'pages.orders')->name('orders');
-
-
-
-
-
-
-
-
-Route::get('/my-past-appointments', [PageController::class, 'pastAppointments'])->name('my-past-appointments');
-Route::get('/pet-history/{id}', function ($id) {
-    return view('pages.pet-history', compact('id'));
-})->name('pet-history');
-Route::get('/appointments/start/{appointment}', [PageController::class, 'startAppointment'])->name('appointments.start');
-Route::get('/appointments/start', [PageController::class, 'selectAppointment'])->name('appointments.select');
-Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+// Public routes
+Route::get('/', function () {
+    return view('home');
+})->name('home');
 Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
 Route::post('/login', [AuthController::class, 'login'])->name('login.post');
 Route::get('/register', [AuthController::class, 'showRegister'])->name('register');
 Route::post('/register', [AuthController::class, 'register'])->name('register.post');
 Route::get('/news', [PageController::class, 'news'])->name('news');
 
-Route::get('/', function () {
-    return view('home');
-})->name('home');
-Route::get('/change-roles', function () {
-    return view('pages.change-roles');
-})->name('change-roles');
-
+// Routes requiring authentication for any role
 Route::middleware('auth')->group(function () {
-    Route::get('/my-appointments', [PageController::class, 'myAppointments'])->name('my-appointments');
-    Route::get('/users', [PageController::class, 'users'])->name('users');
-    Route::get('/veterinarians', [PageController::class, 'veterinarians'])->name('veterinarians');
-    Route::get('/pets', [PageController::class, 'pets'])->name('pets');
-    Route::get('/appointments', [PageController::class, 'appointments'])->name('appointments');
-    Route::get('/services', [PageController::class, 'services'])->name('services');
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+    Route::get('/services', [PageController::class, 'services'])->name('services');
+    Route::get('/pet-history/{id}', function ($id) {
+        return view('pages.pet-history', compact('id'));
+    })->name('pet-history');
+});
+
+// Client routes
+Route::middleware(['auth', 'role:client'])->group(function () {
     Route::get('/about', [PageController::class, 'aboutMe'])->name('about');
     Route::post('/profile/update', [PageController::class, 'updateProfileUser'])->name('profile.update');
     Route::post('/pets/store', [PageController::class, 'storePet'])->name('pets.store');
+    Route::get('/my-appointments', [PageController::class, 'myAppointments'])->name('my-appointments');
+    Route::get('/my-past-appointments', [PageController::class, 'pastAppointments'])->name('my-past-appointments');
+});
 
+// Veterinarian routes
+Route::middleware(['auth', 'role:vet'])->group(function () {
+    Route::get('/appointments/start/{appointment}', [PageController::class, 'startAppointment'])->name('appointments.start');
+    Route::get('/appointments/start', [PageController::class, 'selectAppointment'])->name('appointments.select');
+});
+
+// Routes for vet and administrators
+Route::middleware(['auth', 'role:vet,admin,superadmin'])->group(function () {
+    Route::get('/appointments', [PageController::class, 'appointments'])->name('appointments');
+});
+
+// Admin routes
+Route::middleware(['auth', 'role:admin,superadmin'])->group(function () {
+    Route::get('/users', [PageController::class, 'users'])->name('users');
+    Route::get('/pets', [PageController::class, 'pets'])->name('pets');
+});
+
+// Superadmin routes
+Route::middleware(['auth', 'role:superadmin'])->group(function () {
+    Route::view('/orders', 'pages.orders')->name('orders');
+    Route::get('/veterinarians', [PageController::class, 'veterinarians'])->name('veterinarians');
+    Route::get('/change-roles', function () {
+        return view('pages.change-roles');
+    })->name('change-roles');
 });


### PR DESCRIPTION
## Summary
- secure protected pages using `role` middleware
- register middleware aliases and stateful API support
- protect API routes with `auth:sanctum`

## Testing
- `php -l backend/bootstrap/app.php` *(fails: php not installed)*
- `php -l backend/routes/web.php` *(fails: php not installed)*
- `php -l backend/routes/api.php` *(fails: php not installed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683bf8e7f4a8832c8593349eddb0b1c0